### PR TITLE
docs: update ROADMAP release line from v1.4.x to v1.6.x

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> **Last updated**: 2026-03-20
+> **Last updated**: 2026-08-24
 >
 > This roadmap reflects current priorities. For the ecosystem-wide view, see the
 > [CUBRID Labs Ecosystem Roadmap](https://github.com/cubrid-lab/.github/blob/main/ROADMAP.md).
@@ -11,13 +11,13 @@
 - 🗂️ [Org Project Board](https://github.com/orgs/cubrid-lab/projects/2)
 - 🌐 [Ecosystem Roadmap](https://github.com/cubrid-lab/.github/blob/main/ROADMAP.md)
 
-## Current Release Line — v1.4.x — Stable Maintenance & Polish
+## Current Release Line — v1.6.x — Stable Maintenance & Polish
 
 - Documentation accuracy and consistency across README / docs / AI-facing project files
 - Continued SQLAlchemy 2.0–2.2 hardening while preparing for SA 2.2 validation
 - Reflection/autogenerate polish and benchmark-driven performance tuning
 
-## Next Minor — v1.5.x — Performance & Ecosystem
+## Next — Performance & Ecosystem
 
 - Performance profiling and benchmark integration
 - Ecosystem examples and cookbook expansion


### PR DESCRIPTION
Closes #277.

## Summary
`ROADMAP.md` described "Current Release Line — v1.4.x" and "Next Minor — v1.5.x" (last updated 2026-03-20), but **1.6.0** has shipped (`sqlalchemy_cubrid/__init__.py`; PyPI 1.6.0 uploaded 2026-07-18 — confirmed via the PyPI JSON API), so both labels were stale.

- Current Release Line v1.4.x → **v1.6.x**.
- Removed the stale `v1.5.x` version label from the forward-looking section (v1.5.x already shipped), keeping the still-valid themes.
- Refreshed the "Last updated" date.

Kept conservative: did not invent specific unreleased version numbers or milestone content.

**Do not merge** — opened for review per request.