### PR TITLE
docs: recommend cubrid+pycubrid:// and clarify legacy CUBRIDdb default

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ pip install "sqlalchemy-cubrid[alembic]"
 ```python
 from sqlalchemy import create_engine, text
 
-engine = create_engine("cubrid://dba:password@localhost:33000/demodb")
+engine = create_engine("cubrid+pycubrid://dba:password@localhost:33000/demodb")
 
 with engine.connect() as conn:
     result = conn.execute(text("SELECT 1"))
@@ -121,7 +121,7 @@ class User(Base):
     email: Mapped[str] = mapped_column(String(200), unique=True)
 
 
-engine = create_engine("cubrid://dba:password@localhost:33000/demodb")
+engine = create_engine("cubrid+pycubrid://dba:password@localhost:33000/demodb")
 Base.metadata.create_all(engine)
 
 with Session(engine) as session:
@@ -230,10 +230,10 @@ after the statement (see [Known Limitations](#known-limitations)).
 
 ```python
 from sqlalchemy import create_engine
-engine = create_engine("cubrid://dba:password@localhost:33000/demodb")
+engine = create_engine("cubrid+pycubrid://dba:password@localhost:33000/demodb")
 ```
 
-For the pure Python driver (no C build needed): `create_engine("cubrid+pycubrid://dba@localhost:33000/demodb")`
+The bare `cubrid://` URL uses the legacy `CUBRID-Python` C-extension driver (requires compilation): `create_engine("cubrid://dba:password@localhost:33000/demodb")`.
 
 ### Does sqlalchemy-cubrid support SQLAlchemy 2.0–2.2?
 

--- a/sqlalchemy_cubrid/dialect.py
+++ b/sqlalchemy_cubrid/dialect.py
@@ -280,9 +280,11 @@ class CubridDialect(default.DefaultDialect):
             import CUBRIDdb as cubrid_dbapi  # type: ignore[import-not-found]  # pyright: ignore[reportMissingImports]
         except ImportError as e:
             raise ImportError(
-                "Could not import CUBRIDdb. Install 'CUBRID-Python' for "
-                "cubrid:// URLs, or use cubrid+pycubrid:// with 'pycubrid': "
-                "pip install CUBRID-Python"
+                "Could not import CUBRIDdb. The bare cubrid:// URL uses the "
+                "legacy CUBRID-Python C-extension driver. Either install it "
+                "(pip install CUBRID-Python), or switch to the maintained "
+                "pure-Python driver with a cubrid+pycubrid:// URL "
+                "(pip install \"sqlalchemy-cubrid[pycubrid]\")."
             ) from e
         return cast(DBAPIModule, cubrid_dbapi)  # pyright: ignore[reportInvalidCast]
 

--- a/sqlalchemy_cubrid/dialect.py
+++ b/sqlalchemy_cubrid/dialect.py
@@ -284,7 +284,7 @@ class CubridDialect(default.DefaultDialect):
                 "legacy CUBRID-Python C-extension driver. Either install it "
                 "(pip install CUBRID-Python), or switch to the maintained "
                 "pure-Python driver with a cubrid+pycubrid:// URL "
-                "(pip install \"sqlalchemy-cubrid[pycubrid]\")."
+                '(pip install "sqlalchemy-cubrid[pycubrid]").'
             ) from e
         return cast(DBAPIModule, cubrid_dbapi)  # pyright: ignore[reportInvalidCast]
 


### PR DESCRIPTION
Closes #275.

## Summary
The maintained driver is [`pycubrid`](https://github.com/cubrid-lab/pycubrid) (pure Python, v1.6.2), but the bare `cubrid://` URL binds to the unmaintained 2015 `CUBRID-Python` C-extension (`CUBRIDdb`) — confirmed on PyPI: `CUBRID-Python` latest is **9.3.0, uploaded 2015-01-08, sdist-only, no `Programming Language :: Python :: 3` classifier**.

This is the **safe, non-breaking** slice of the finding (per Oracle review):

- Point the primary README examples (Core, ORM, FAQ) at `cubrid+pycubrid://`.
- Document that bare `cubrid://` is the **legacy** C-extension path.
- Expand the `import_dbapi()` ImportError to offer **both** concrete commands: install `CUBRID-Python` for `cubrid://`, or `pip install "sqlalchemy-cubrid[pycubrid]"` and use `cubrid+pycubrid://`.

## Explicitly out of scope
- **Does NOT change the default DBAPI mapping** for bare `cubrid://` or the `[cubrid]` extra. Flipping the default is behavior-breaking and is tracked as a separate maintainer-decision issue (#276) — changing the extra while `cubrid://` still imports `CUBRIDdb` would create a broken install path.

## Verification
- `python -c "import ast; ast.parse(...)"` on `dialect.py`: syntax OK.
- `lsp_diagnostics`: only pre-existing unrelated errors (lines 371/406); edit region clean.

**Do not merge** — opened for review per request.