### PR TITLE
ci: add docs-sync guard to prevent stale docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@
 - [ ] I have run `make check` (lint + typecheck)
 - [ ] I have run `make test` and all tests pass
 - [ ] I have added tests for new functionality (if applicable)
-- [ ] I have updated documentation (if applicable)
+- [ ] I have updated documentation for any behavior/API/version/config change (or set `Docs: not needed - <reason>` / applied the `docs-not-needed` label)
 - [ ] My changes do not introduce new warnings
 
 ## Related Issues

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -6,13 +6,13 @@ name: docs-sync
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled, edited]
 
 jobs:
   docs-sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -44,7 +44,7 @@ jobs:
             **/*.rst
             **/*.txt
         run: |
-          git fetch origin "$BASE_REF" --depth=1
+          git fetch origin "$BASE_REF"
           python - <<'PY'
           import fnmatch, json, os, subprocess, sys
 
@@ -63,7 +63,8 @@ jobs:
           def matches(path, patterns):
               return any(fnmatch.fnmatch(path, pat) for pat in patterns)
 
-          event = json.load(open(os.environ["EVENT_PATH"]))
+          with open(os.environ["EVENT_PATH"]) as _f:
+              event = json.load(_f)
           pr = event.get("pull_request", {})
           labels = {label["name"] for label in pr.get("labels", [])}
           body = pr.get("body") or ""

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,93 @@
+name: docs-sync
+
+# Fails a PR when behavior-relevant source changes land without a matching
+# documentation/changelog update. Escape hatch: add the `docs-not-needed`
+# label OR put `Docs: not needed - <reason>` in the PR body.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  docs-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check behavior changes have docs updates
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_PATH: ${{ github.event_path }}
+
+          # Behavior-relevant source/config. Override per repo.
+          IMPACT_GLOBS: |
+            sqlalchemy_cubrid/**
+            pyproject.toml
+            setup.cfg
+            setup.py
+
+          # Docs that count as "kept in sync".
+          DOC_GLOBS: |
+            CHANGELOG*
+            README*
+            docs/**
+            SUPPORT_MATRIX*
+
+          # Changes that never require doc churn.
+          IGNORE_GLOBS: |
+            tests/**
+            **/tests/**
+            .github/**
+            **/*.md
+            **/*.rst
+            **/*.txt
+        run: |
+          git fetch origin "$BASE_REF" --depth=1
+          python - <<'PY'
+          import fnmatch, json, os, subprocess, sys
+
+          base = f"origin/{os.environ['BASE_REF']}"
+          changed = subprocess.check_output(
+              ["git", "diff", "--name-only", f"{base}...HEAD"], text=True
+          ).splitlines()
+
+          def globs(name):
+              return [x.strip() for x in os.environ[name].splitlines() if x.strip()]
+
+          impact_globs = globs("IMPACT_GLOBS")
+          doc_globs = globs("DOC_GLOBS")
+          ignore_globs = globs("IGNORE_GLOBS")
+
+          def matches(path, patterns):
+              return any(fnmatch.fnmatch(path, pat) for pat in patterns)
+
+          event = json.load(open(os.environ["EVENT_PATH"]))
+          pr = event.get("pull_request", {})
+          labels = {label["name"] for label in pr.get("labels", [])}
+          body = pr.get("body") or ""
+
+          skipped = "docs-not-needed" in labels or "Docs: not needed -" in body
+          doc_changed = any(matches(p, doc_globs) for p in changed)
+          relevant = [
+              p for p in changed
+              if matches(p, impact_globs) and not matches(p, ignore_globs)
+          ]
+
+          print("Changed files:")
+          for p in changed:
+              print(f"  {p}")
+
+          if relevant and not doc_changed and not skipped:
+              print("\nDocs-sync guard failed.")
+              print("Behavior-relevant files changed without a matching docs/changelog update.")
+              print("Either update docs, or add the `docs-not-needed` label / PR body marker:")
+              print("  Docs: not needed - <reason>")
+              print("\nRelevant files:")
+              for p in relevant:
+                  print(f"  {p}")
+              sys.exit(1)
+
+          print("\nDocs-sync guard passed.")
+          PY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,6 +254,14 @@ The dialect translates automatically in `create_connect_args()`.
 | `docs/DRIVER_COMPAT.md` | CUBRID-Python driver versions and known issues |
 | `docs/TROUBLESHOOTING.md` | Common issues, error solutions, debugging techniques |
 
+## Documentation definition of done
+
+Any change that affects public behavior, compatibility, installation, configuration, APIs, supported versions, error handling, or SQL/dialect behavior MUST update the matching documentation in the **same PR**. At minimum keep in sync: `CHANGELOG.md`, the relevant files under `docs/` (e.g. `FEATURE_SUPPORT.md`, `ISOLATION_LEVELS.md`, `TYPES.md`), the `SUPPORT_MATRIX.md`, and version/compatibility claims in `README*`.
+
+If no documentation change is needed, state the reason explicitly in the PR body as `Docs: not needed - <reason>` or apply the `docs-not-needed` label. This is enforced by the `docs-sync` CI check.
+
+Do not mark work complete until code, tests, and documentation are consistent.
+
 ## Commit Convention
 
 ### Format


### PR DESCRIPTION
## Summary

Adds a blocking `docs-sync` CI check so behavior-changing PRs cannot merge without a matching documentation update. Implements the Oracle-reviewed layered approach from #282.

## Changes

- `.github/workflows/docs-sync.yml` — fails when `sqlalchemy_cubrid/**` / packaging changes without a `CHANGELOG`/`docs/`/`SUPPORT_MATRIX`/`README` touch. Ignores tests-only, CI-only, and markdown/docs-only changes. Escape hatch: `docs-not-needed` label **or** `Docs: not needed - <reason>` in the PR body.
- `AGENTS.md` — new "Documentation definition of done" section.
- `.github/PULL_REQUEST_TEMPLATE.md` — checklist item now references the skip mechanism.

## Verification

- YAML parses; guard logic validated locally (same implementation as the pycubrid guard, unit-tested across 7 scenarios).

## Notes

- **Do not merge** — for review only.
- `Docs: not needed - adds CI tooling only; no behavior/API change`

Closes #282