### PR TITLE
ci: exempt Dependabot PRs from docs-sync guard

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -17,6 +17,10 @@ jobs:
           fetch-depth: 0
 
       - name: Check behavior changes have docs updates
+        # Dependency-only Dependabot PRs never carry doc changes; exempt them so
+        # they can auto-merge. Guard on PR author (not actor) so reruns/follow-up
+        # events triggered by a human still skip enforcement for Dependabot PRs.
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
         env:
           BASE_REF: ${{ github.base_ref }}
           EVENT_PATH: ${{ github.event_path }}


### PR DESCRIPTION
## Summary
- Exempt dependency-only Dependabot PRs from the `docs-sync` enforcement step so they can auto-merge.
- Guards on the PR **author** (`github.event.pull_request.user.login != 'dependabot[bot]'`), not the actor, so reruns/follow-up events triggered by a human still skip enforcement for Dependabot PRs.
- The required `docs-sync` check context still reports success (skipped step → job passes), satisfying branch protection.

## Why
Dependabot bump PRs never carry doc changes and have no `docs-not-needed` label/body marker, so `docs-sync` was blocking them (e.g. #284). Prerequisite for reliable Dependabot auto-merge.

## Design
Per Oracle review: exempt inside the same required check (author-based), rather than a separate labeling workflow (avoids timing/rerun races) or coupling Dependabot to a mutable label.

Docs: not needed - CI-only change, no public behavior change