### PR TITLE
docs: clarify get_isolation_level returns canonical names (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+- **Documented canonical isolation-level names on read-back (#293)** — clarified that `get_isolation_level()` returns the *canonical* name for a level, which may differ from the alias passed to `set_isolation_level()` (CUBRID accepts several aliases per numeric level). Added a note to `docs/ISOLATION_LEVELS.md` and the `get_isolation_level()` docstring. Behavior is unchanged; the reverse mapping was already correct.
 ### Changed
 - **Ruff lint rule selection now declared explicitly (#271)** — `pyproject.toml` configured ruff but never set `[tool.ruff.lint] select`, so `ruff check` inherited ruff's implicit defaults. Ruff expanded that default set in 0.16 (59 → 413 rules against this repo's config), which is why #267 (`0.15.21 → 0.16.2`) failed lint with 151 errors in untouched code. Pinning the ruff *version* in #252 stopped unpinned installs from drifting, but could not survive the bump itself — the rule set is now pinned too, via `select = ["E4", "E7", "E9", "F"]`, which is exactly what ruff selected by default through 0.15.x (same 59 rules under both versions).
 

--- a/docs/ISOLATION_LEVELS.md
+++ b/docs/ISOLATION_LEVELS.md
@@ -205,6 +205,16 @@ SELECT X
 
 The returned numeric value is mapped back to a descriptive string.
 
+> **Note — canonical names on read-back.** `get_isolation_level()` returns the
+> **canonical** name for a level, which may differ from the alias you passed to
+> `set_isolation_level()`. CUBRID accepts several aliases that map to the same
+> numeric level (see [Accepted Level Names](#accepted-level-names)) — for
+> example both `"REPEATABLE READ"` and `"REPEATABLE READ SCHEMA, REPEATABLE READ
+> INSTANCES"` map to level 5 — but reading the level resolves the numeric code
+> back through a single canonical entry. A `set` → `get` round-trip therefore
+> returns the canonical name (e.g. `"REPEATABLE READ"`), not necessarily the
+> exact string you supplied.
+
 ### Reset on Connection Return
 
 When a connection is returned to the pool, the dialect resets isolation to level 4 (`READ COMMITTED`) to ensure a clean state for the next checkout.

--- a/sqlalchemy_cubrid/dialect.py
+++ b/sqlalchemy_cubrid/dialect.py
@@ -1012,7 +1012,18 @@ class CubridDialect(default.DefaultDialect):
     _DEFAULT_ISOLATION_CODE: int = 4
 
     def get_isolation_level(self, dbapi_connection: DBAPIConnection) -> str:  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride]
-        """Return the current isolation level for *dbapi_conn*."""
+        """Return the current isolation level for *dbapi_conn*.
+
+        The returned name is the **canonical** name for the level, which may
+        differ from the alias passed to :meth:`set_isolation_level`.  CUBRID's
+        ``_ISOLATION_LEVEL_MAP`` accepts several aliases per numeric level (for
+        example both ``"REPEATABLE READ"`` and
+        ``"REPEATABLE READ SCHEMA, REPEATABLE READ INSTANCES"`` map to code 5),
+        but ``get_isolation_level`` resolves the numeric code back through a
+        single canonical entry.  A ``set`` -> ``get`` round-trip therefore
+        returns the canonical name (e.g. ``"REPEATABLE READ"``), not
+        necessarily the exact string originally supplied.
+        """
         # https://www.cubrid.org/manual/en/11.0/sql/transaction.html
         cursor = dbapi_connection.cursor()
         try:


### PR DESCRIPTION
## Summary
Documentation-only clarification (no behavior change). `get_isolation_level()` returns the **canonical** name for a level, which may differ from the alias passed to `set_isolation_level()` — CUBRID's `_ISOLATION_LEVEL_MAP` accepts several aliases per numeric code, while the reverse mapping has one canonical entry per code. A `set` → `get` round-trip therefore returns the canonical name (e.g. `"REPEATABLE READ"`), not necessarily the exact string supplied.

Documented in `docs/ISOLATION_LEVELS.md` (note under "Reading Current Level") and in the `get_isolation_level()` docstring.

Closes #293.

## Docs
CHANGELOG updated under Unreleased → Docs (#293).

Docs: this IS the documentation change.