### PR TITLE
docs: align pyproject Documentation URL with README badge (#294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 - **Documented canonical isolation-level names on read-back (#293)** — clarified that `get_isolation_level()` returns the *canonical* name for a level, which may differ from the alias passed to `set_isolation_level()` (CUBRID accepts several aliases per numeric level). Added a note to `docs/ISOLATION_LEVELS.md` and the `get_isolation_level()` docstring. Behavior is unchanged; the reverse mapping was already correct.
+- **Aligned the `Documentation` project URL with the README docs badge (#294)** — `pyproject.toml` pointed `Documentation` at the repo tree (`.../tree/main/docs`) while the README badge pointed at the published site `https://cubrid-lab.github.io/sqlalchemy-cubrid/`. Both now use the published site so PyPI metadata and the README agree.
 ### Changed
 - **Ruff lint rule selection now declared explicitly (#271)** — `pyproject.toml` configured ruff but never set `[tool.ruff.lint] select`, so `ruff check` inherited ruff's implicit defaults. Ruff expanded that default set in 0.16 (59 → 413 rules against this repo's config), which is why #267 (`0.15.21 → 0.16.2`) failed lint with 151 errors in untouched code. Pinning the ruff *version* in #252 stopped unpinned installs from drifting, but could not survive the bump itself — the rule set is now pinned too, via `select = ["E4", "E7", "E9", "F"]`, which is exactly what ruff selected by default through 0.15.x (same 59 rules under both versions).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ pycubrid = [
 [project.urls]
 Homepage = "https://github.com/cubrid-lab/sqlalchemy-cubrid"
 Repository = "https://github.com/cubrid-lab/sqlalchemy-cubrid"
-Documentation = "https://github.com/cubrid-lab/sqlalchemy-cubrid/tree/main/docs"
+Documentation = "https://cubrid-lab.github.io/sqlalchemy-cubrid/"
 Changelog = "https://github.com/cubrid-lab/sqlalchemy-cubrid/blob/main/CHANGELOG.md"
 Issues = "https://github.com/cubrid-lab/sqlalchemy-cubrid/issues"
 


### PR DESCRIPTION
## Summary
`pyproject.toml` set the `Documentation` project URL to the repo tree (`.../tree/main/docs`) while the README docs badge already pointed at the published site `https://cubrid-lab.github.io/sqlalchemy-cubrid/`. This aligns the `Documentation` URL to the published site so PyPI metadata and the README agree.

Scope is URL alignment only — the README badge was already correct, so no README change was needed.

Closes #294.

## Docs
CHANGELOG updated under Unreleased → Docs (#294). This change IS packaging/docs metadata.