### PR TITLE
docs: add independence/non-affiliation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and [docs/DEVELOPMENT.md](
 
 Report vulnerabilities via email -- see [SECURITY.md](SECURITY.md). Do not open public issues for security concerns.
 
+## Disclaimer
+
+> This project is part of [CUBRID Lab](https://github.com/cubrid-lab), an independent open-source initiative for CUBRID developer tooling, and is not affiliated with, sponsored by, or endorsed by CUBRID Corporation or the official CUBRID project.
+
+
 ## License
 
 MIT -- see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Adds a one-line **independence / non-affiliation notice** (a `## Disclaimer` section above `## License`) so first-time visitors understand this repo is part of [CUBRID Lab](https://github.com/cubrid-lab) — an independent, community-driven open-source initiative building tooling **for** CUBRID — and is **not** affiliated with, sponsored by, or endorsed by CUBRID Corporation or the official CUBRID project.

Mirrors the org-profile notice (cubrid-lab/.github#29). Wording reviewed with Oracle; avoids implying endorsement and avoids over-disclaiming into "unrelated to CUBRID".

Docs: not needed - README-only non-affiliation notice; no code, config, tool, or behavior change.