### PR TITLE
ci: auto-create GitHub Releases from CHANGELOG sections

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,93 @@
+name: Create GitHub Release
+
+# Creates a GitHub Release from the CHANGELOG section for a pushed vX.Y.Z tag.
+# The CHANGELOG is the single source of truth: release notes are the extracted
+# "## [X.Y.Z] - YYYY-MM-DD" section (fail-closed, no generated-notes fallback).
+# Publishing the Release triggers publish-pypi.yml (on: release: published).
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to (re)create the release for, e.g. v1.2.3'
+        required: true
+        type: string
+      update_existing:
+        description: 'Overwrite an existing release body if it differs'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Resolve tag and version
+        id: resolve
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          case "$TAG" in
+            v[0-9]*) ;;
+            *) echo "ERROR: tag '$TAG' is not a vX.Y.Z tag" >&2; exit 1 ;;
+          esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag is on main
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.resolve.outputs.tag }}"
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$TAG" origin/main; then
+            echo "ERROR: tag '$TAG' is not an ancestor of origin/main; refusing to release" >&2
+            exit 1
+          fi
+
+      - name: Extract release notes from CHANGELOG
+        run: python3 scripts/extract_release_notes.py "${{ steps.resolve.outputs.tag }}"
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+          UPDATE_EXISTING: ${{ github.event.inputs.update_existing }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            EXISTING="$(gh release view "$TAG" --json body -q .body || true)"
+            NEW="$(cat RELEASE_NOTES.md)"
+            if [ "$EXISTING" = "$NEW" ]; then
+              echo "Release $TAG already up to date; nothing to do."
+              exit 0
+            fi
+            if [ "${UPDATE_EXISTING:-false}" = "true" ]; then
+              echo "Updating existing release $TAG."
+              gh release edit "$TAG" --title "$TAG" --notes-file RELEASE_NOTES.md
+            else
+              echo "ERROR: release $TAG exists and differs; re-run via workflow_dispatch with update_existing=true" >&2
+              exit 1
+            fi
+          else
+            echo "Creating release $TAG."
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes-file RELEASE_NOTES.md \
+              --verify-tag \
+              --target "$TAG"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,10 +317,20 @@ Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>
    `version = {attr = "sqlalchemy_cubrid.__version__"}`), so it is the single source of truth.
 2. Add a dated changelog entry in `CHANGELOG.md` (`## [x.y.z] - YYYY-MM-DD`)
 3. Open a PR and merge to `main` (direct pushes are not allowed)
-4. Create a GitHub Release (`v{major}.{minor}.{patch}`) on the merged commit via `gh release create`
-5. Publishing the GitHub Release triggers `.github/workflows/publish-pypi.yml`,
+4. Push the tag `v{major}.{minor}.{patch}` on the merged commit:
+   `git tag vx.y.z <merged-sha> && git push origin vx.y.z` (tag pushes are allowed; only
+   direct branch pushes to `main` are forbidden).
+5. The tag push triggers `.github/workflows/create-release.yml`, which extracts the
+   `## [x.y.z] - YYYY-MM-DD` section from `CHANGELOG.md` (fail-closed — no fallback) and
+   creates the GitHub Release titled `vx.y.z` with that body, after verifying the tag is
+   an ancestor of `origin/main`.
+6. Publishing the GitHub Release triggers `.github/workflows/publish-pypi.yml`,
    which rebuilds, verifies (tag == version, dated CHANGELOG, tag on main, smoke tests),
    and publishes to PyPI via Trusted Publisher (OIDC).
+
+Release notes are never hand-written: `CHANGELOG.md` is the single source of truth and
+`scripts/extract_release_notes.py` renders the Release body. To re-create a release body,
+re-run `create-release.yml` via `workflow_dispatch` with `update_existing: true`.
 
 ## Project Context — Performance Loop System
 

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Extract a single version's section from CHANGELOG.md for GitHub Release notes.
+
+The CHANGELOG is the single source of truth for release notes. This script is
+fail-closed: if the requested version has no dated section (or the section is
+empty), it exits non-zero and writes nothing. There is no fallback to generated
+notes or the whole changelog.
+
+Usage:
+    python scripts/extract_release_notes.py vX.Y.Z
+
+On success, writes the section body (without the header line) to
+RELEASE_NOTES.md in the current working directory.
+
+Exit codes:
+    0 — section extracted and written to RELEASE_NOTES.md
+    1 — missing or empty CHANGELOG section for the requested version
+    2 — usage error
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: extract_release_notes.py vX.Y.Z", file=sys.stderr)
+        return 2
+
+    tag = sys.argv[1]
+    version = tag[1:] if tag.startswith("v") else tag
+
+    changelog = pathlib.Path("CHANGELOG.md")
+    if not changelog.exists():
+        print("ERROR: CHANGELOG.md not found", file=sys.stderr)
+        return 1
+
+    text = changelog.read_text(encoding="utf-8")
+    header_re = re.compile(
+        rf"^## \[{re.escape(version)}\] - \d{{4}}-\d{{2}}-\d{{2}}\s*$",
+        re.MULTILINE,
+    )
+    match = header_re.search(text)
+    if not match:
+        print(f"ERROR: Missing dated CHANGELOG section for {version}", file=sys.stderr)
+        return 1
+
+    next_match = re.search(r"^## \[", text[match.end() :], re.MULTILINE)
+    end = match.end() + next_match.start() if next_match else len(text)
+    body = text[match.end() : end].strip()
+    if not body:
+        print(f"ERROR: Empty CHANGELOG section for {version}", file=sys.stderr)
+        return 1
+
+    pathlib.Path("RELEASE_NOTES.md").write_text(body + "\n", encoding="utf-8")
+    print(f"OK: wrote RELEASE_NOTES.md for {version} ({len(body)} chars)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add `.github/workflows/create-release.yml`: on a `v*` tag push (or `workflow_dispatch`), verifies the tag is an ancestor of `origin/main`, extracts the dated CHANGELOG section, and creates a GitHub Release titled `vX.Y.Z` with that body. Publishing the release chains into `publish-pypi.yml`.
- Add `scripts/extract_release_notes.py`: fail-closed extractor (no generated-notes / whole-changelog fallback).
- Update AGENTS.md Release Process to the tag-push-driven flow.

Makes CHANGELOG.md the single source of truth for release notes and standardizes release titles to `vX.Y.Z`.

Docs: not needed - CI/release tooling only; AGENTS.md release process updated in this PR.