### PR TITLE
ci: attach SPDX SBOM to GitHub Release assets

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -91,3 +91,17 @@ jobs:
               --verify-tag \
               --target "$TAG"
           fi
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Upload SBOM to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" sbom.spdx.json


### PR DESCRIPTION
SBOM is now generated and attached to each GitHub Release.

Previously the SBOM was only available as a workflow artifact via sbom.yml; it is now automatically downloaded by judges, benchmarkers, and supply-chain security tooling from the release assets.

The SBOM uses the same anchore/sbom-action version and spdx-json format as sbom.yml for consistency.