### PR TITLE
docs: add THIRD_PARTY_LICENSES.md and Provenance note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+- **Added `THIRD_PARTY_LICENSES.md` and a Provenance section in `docs/ARCHITECTURE.md`** — the license inventory covers the default runtime tree (SQLAlchemy, greenlet, typing_extensions) and the optional `[alembic]`/`[cubrid]` extras; the provenance note states that this dialect is an independent implementation, not a port of the legacy `CUBRID-Python`-bundled dialect. Documentation only.
+
 ## [1.7.0] - 2026-09-02
 
 ### Docs

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,14 @@
+# Third-Party Software Licenses
+
+This file lists the third-party open-source software involved in building and testing **sqlalchemy-cubrid**.
+
+Optional extras: `[alembic]` adds Alembic (MIT) and Mako (MIT); `[cubrid]`/`[cubriddb]` add the legacy C-extension driver CUBRID-Python (BSD). Neither extra is installed by default.
+All listed dependencies are distributed under permissive licenses (MIT, BSD-2/3-Clause, Apache-2.0, ISC, PSF, MPL-2.0). No dependency is copyleft/GPL, and none conflicts with this project's MIT license. MPL-2.0 packages appear in the development toolchain only and are not distributed with the package.
+
+## Runtime dependencies (default install)
+
+| Name              | Version | License         | URL                                             |
+|-------------------|---------|-----------------|-------------------------------------------------|
+| SQLAlchemy        | 2.0.52  | MIT             | https://www.sqlalchemy.org                      |
+| greenlet          | 3.5.5   | MIT AND PSF-2.0 | https://greenlet.readthedocs.io                 |
+| typing_extensions | 4.16.0  | PSF-2.0         | https://github.com/python/typing_extensions     |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,6 +10,14 @@ sqlalchemy-cubrid is designed to provide a robust, modern interface between SQLA
 *   Alembic migration support
 *   PEP 561 typed
 
+## Provenance
+
+sqlalchemy-cubrid is an independent implementation written for SQLAlchemy 2.0. It
+contains no code from, and is not a port of, the legacy CUBRID SQLAlchemy dialect
+that shipped inside the old `CUBRID-Python` driver distribution. The optional
+`[cubrid]`/`[cubriddb]` extras merely allow this dialect to *run on top of* that
+legacy driver; no source from it is included or derived.
+
 ## High-Level Flow
 
 ### Phase 1: Engine Creation & Connection


### PR DESCRIPTION
## Summary
- `THIRD_PARTY_LICENSES.md`: default runtime tree (SQLAlchemy 2.0 MIT, greenlet MIT/PSF, typing_extensions PSF) plus optional extras documented (`[alembic]` → Alembic/Mako MIT; `[cubrid]`/`[cubriddb]` → legacy CUBRID-Python driver, BSD). All permissive; no GPL.
- `docs/ARCHITECTURE.md` gains a **Provenance** section: this dialect is an independent implementation — no code from, or port of, the legacy CUBRID SQLAlchemy dialect that shipped inside the old `CUBRID-Python` distribution. The extras merely allow running *on top of* that driver.
- CHANGELOG `[Unreleased]` entry added (docs-sync).