### PR TITLE
docs: CUBRID-Python BSD basis, server-license line, NOTICE, unified copyright

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Docs
+- **CUBRID-Python BSD basis documented, server-license line added, NOTICE created, copyright unified (#333)** — `THIRD_PARTY_LICENSES.md` now records that the optional CUBRID-Python extra's `BSD` claim rests on PyPI metadata and setup.py (the upstream repository ships no LICENSE file or headers; 2- vs 3-Clause unspecified), and carries the verified CUBRID server licensing statement (engine Apache-2.0, APIs/connectors BSD per upstream `COPYING` — GPL v2+ is outdated). Added a two-line `NOTICE` (independent implementation, no third-party code). LICENSE copyright unified to `Yeongseon Choe and Gyeongjun Paik` (2021-2026).
+
+### Docs
 - **Added `THIRD_PARTY_LICENSES.md` and a Provenance section in `docs/ARCHITECTURE.md`** — the license inventory covers the default runtime tree (SQLAlchemy, greenlet, typing_extensions) and the optional `[alembic]`/`[cubrid]` extras; the provenance note states that this dialect is an independent implementation, not a port of the legacy `CUBRID-Python`-bundled dialect. Documentation only.
 
 ## [1.7.0] - 2026-09-02

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Yeongseon Choe
+Copyright (c) 2021-2026 Yeongseon Choe and Gyeongjun Paik
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,9 @@
+sqlalchemy-cubrid
+Copyright (c) 2021-2026 Yeongseon Choe and Gyeongjun Paik
+
+This product is licensed under the MIT License (see LICENSE).
+
+sqlalchemy-cubrid is an independent implementation written for
+SQLAlchemy 2.0. It contains no third-party source code and embeds no
+third-party assets; see docs/ARCHITECTURE.md (Provenance) and
+THIRD_PARTY_LICENSES.md for the dependency license inventory.

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -2,7 +2,14 @@
 
 This file lists the third-party open-source software involved in building and testing **sqlalchemy-cubrid**.
 
-Optional extras: `[alembic]` adds Alembic (MIT) and Mako (MIT); `[cubrid]`/`[cubriddb]` add the legacy C-extension driver CUBRID-Python (BSD). Neither extra is installed by default.
+Optional extras: `[alembic]` adds Alembic (MIT) and Mako (MIT); `[cubrid]`/`[cubriddb]` add the legacy C-extension driver CUBRID-Python (BSD; per PyPI metadata `license=BSD` and the package's setup.py declaration — the upstream cubrid/cubrid-python repository ships no LICENSE file or license headers, so 2- vs 3-Clause is unspecified). Neither extra is installed by default.
+
+> **CUBRID server license, for the record.** The CUBRID server engine is
+> distributed under Apache License 2.0 and the official APIs/connectors under
+> BSD (upstream `COPYING`, http://www.cubrid.org/cubrid) — the frequently cited
+> GPL v2+ no longer applies. This project is an independent wire-protocol client
+> that neither includes nor links any CUBRID server code; the `cubrid/cubrid`
+> Docker image is used for CI verification only.
 All listed dependencies are distributed under permissive licenses (MIT, BSD-2/3-Clause, Apache-2.0, ISC, PSF, MPL-2.0). No dependency is copyleft/GPL, and none conflicts with this project's MIT license. MPL-2.0 packages appear in the development toolchain only and are not distributed with the package.
 
 ## Runtime dependencies (default install)


### PR DESCRIPTION
Fixes #333

- TPL: CUBRID-Python optional extra's BSD claim now carries its basis — PyPI metadata license=BSD + setup.py declaration; upstream cubrid/cubrid-python ships no LICENSE file or headers (2- vs 3-Clause unspecified). Also adds the verified server-license statement (engine Apache-2.0 / APIs+connectors BSD per upstream COPYING; GPL v2+ outdated).
- New two-line NOTICE (independent implementation, no third-party code) — was the only repo of the four without one.
- LICENSE copyright to 'Yeongseon Choe and Gyeongjun Paik' (2021-2026).