### PR TITLE
docs: comma-separated copyright holders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Docs
-- **CUBRID-Python BSD basis documented, server-license line added, NOTICE created, copyright unified (#333)** — `THIRD_PARTY_LICENSES.md` now records that the optional CUBRID-Python extra's `BSD` claim rests on PyPI metadata and setup.py (the upstream repository ships no LICENSE file or headers; 2- vs 3-Clause unspecified), and carries the verified CUBRID server licensing statement (engine Apache-2.0, APIs/connectors BSD per upstream `COPYING` — GPL v2+ is outdated). Added a two-line `NOTICE` (independent implementation, no third-party code). LICENSE copyright unified to `Yeongseon Choe and Gyeongjun Paik` (2021-2026).
+- **CUBRID-Python BSD basis documented, server-license line added, NOTICE created, copyright unified (#333)** — `THIRD_PARTY_LICENSES.md` now records that the optional CUBRID-Python extra's `BSD` claim rests on PyPI metadata and setup.py (the upstream repository ships no LICENSE file or headers; 2- vs 3-Clause unspecified), and carries the verified CUBRID server licensing statement (engine Apache-2.0, APIs/connectors BSD per upstream `COPYING` — GPL v2+ is outdated). Added a two-line `NOTICE` (independent implementation, no third-party code). LICENSE copyright unified to `Yeongseon Choe, Gyeongjun Paik` (2021-2026).
 
 ### Docs
 - **Added `THIRD_PARTY_LICENSES.md` and a Provenance section in `docs/ARCHITECTURE.md`** — the license inventory covers the default runtime tree (SQLAlchemy, greenlet, typing_extensions) and the optional `[alembic]`/`[cubrid]` extras; the provenance note states that this dialect is an independent implementation, not a port of the legacy `CUBRID-Python`-bundled dialect. Documentation only.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2026 Yeongseon Choe and Gyeongjun Paik
+Copyright (c) 2021-2026 Yeongseon Choe, Gyeongjun Paik
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 sqlalchemy-cubrid
-Copyright (c) 2021-2026 Yeongseon Choe and Gyeongjun Paik
+Copyright (c) 2021-2026 Yeongseon Choe, Gyeongjun Paik
 
 This product is licensed under the MIT License (see LICENSE).
 


### PR DESCRIPTION
Copyright line reads `Yeongseon Choe, Gyeongjun Paik` (comma instead of `and`), consistent across LICENSE, NOTICE, and the unreleased changelog entry.