### PR TITLE
ci: drop --target from gh release create (422 on existing tags)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -88,8 +88,7 @@ jobs:
             gh release create "$TAG" \
               --title "$TAG" \
               --notes-file RELEASE_NOTES.md \
-              --verify-tag \
-              --target "$TAG"
+              --verify-tag
           fi
 
       - name: Generate SBOM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **create-release.yml: dropped `--target` from `gh release create`** — with an already-pushed tag (the normal tag-push trigger) `--verify-tag` already guarantees the tag exists, and passing `target_commitish` for an existing tag makes the Releases API return `422 Validation Failed`, so the first tag-triggered run of this workflow always failed. Verified live by the v0.4.0 tag attempt in cubrid-mcp-server.
+
 ### Docs
 - **CUBRID-Python BSD basis documented, server-license line added, NOTICE created, copyright unified (#333)** — `THIRD_PARTY_LICENSES.md` now records that the optional CUBRID-Python extra's `BSD` claim rests on PyPI metadata and setup.py (the upstream repository ships no LICENSE file or headers; 2- vs 3-Clause unspecified), and carries the verified CUBRID server licensing statement (engine Apache-2.0, APIs/connectors BSD per upstream `COPYING` — GPL v2+ is outdated). Added a two-line `NOTICE` (independent implementation, no third-party code). LICENSE copyright unified to `Yeongseon Choe, Gyeongjun Paik` (2021-2026).
 


### PR DESCRIPTION
Preventive: same canonical-workflow bug verified live in cubrid-mcp-server's v0.4.0 attempt — `target_commitish` on an existing tag returns 422. This repo has never run this workflow yet, so the bug was unexposed.