### PR TITLE
docs: fix cubrid-cookbook repo link, drop private Project Board link

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Yes. Use `create_async_engine("cubrid+aiopycubrid://...")` with the pycubrid asy
 
 See [`ROADMAP.md`](ROADMAP.md) for this project's direction and next milestones.
 
-For the ecosystem-wide view, see the [CUBRID Labs Ecosystem Roadmap](https://github.com/cubrid-lab/.github/blob/main/ROADMAP.md) and [Project Board](https://github.com/orgs/cubrid-lab/projects/2).
+For the ecosystem-wide view, see the [CUBRID Labs Ecosystem Roadmap](https://github.com/cubrid-lab/.github/blob/main/ROADMAP.md).
 
 ## Contributing
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -538,7 +538,7 @@ AI agents can discover, learn, and recommend sqlalchemy-cubrid accurately.
 
 ### Cookbook Integration
 
-The [cubrid-cookbook](https://github.com/cubrid-lab/cubrid-cookbook) repository provides
+The [cubrid-cookbook](https://github.com/cubrid-lab/cubrid-cookbook-python) repository provides
 runnable examples for sqlalchemy-cubrid:
 
 | Example | Description |

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -234,7 +234,7 @@ Ja. Verwenden Sie `create_async_engine("cubrid+aiopycubrid://...")` mit dem pycu
 
 Siehe [`ROADMAP.md`](../ROADMAP.md) für die Ausrichtung des Projekts und die nächsten Meilensteine.
 
-Für die Ökosystem-Perspektive siehe die [CUBRID Labs Ecosystem Roadmap](https://github.com/cubrid-lab/.github/blob/main/ROADMAP.md) und das [Project Board](https://github.com/orgs/cubrid-lab/projects/2).
+Für die Ökosystem-Perspektive siehe die [CUBRID Labs Ecosystem Roadmap](https://github.com/cubrid-lab/.github/blob/main/ROADMAP.md).
 
 ## Mitwirken
 

--- a/docs/README.hi.md
+++ b/docs/README.hi.md
@@ -233,7 +233,7 @@ stmt = insert(users).values(name="Alice").on_duplicate_key_update(name="Alice Up
 
 इस परियोजना की दिशा और अगले milestones के लिए [`ROADMAP.md`](../ROADMAP.md) देखें।
 
-पूरे ecosystem के दृष्टिकोण के लिए [CUBRID Labs Ecosystem Roadmap](https://github.com/cubrid-lab/.github/blob/main/ROADMAP.md) और [Project Board](https://github.com/orgs/cubrid-lab/projects/2) देखें।
+पूरे ecosystem के दृष्टिकोण के लिए [CUBRID Labs Ecosystem Roadmap](https://github.com/cubrid-lab/.github/blob/main/ROADMAP.md) देखें।
 
 ## योगदान
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -233,7 +233,7 @@ stmt = insert(users).values(name="Alice").on_duplicate_key_update(name="Alice Up
 
 이 프로젝트의 방향과 다음 마일스톤은 [`ROADMAP.md`](../ROADMAP.md)를 참고하세요.
 
-생태계 전체 관점은 [CUBRID Labs Ecosystem Roadmap](https://github.com/cubrid-lab/.github/blob/main/ROADMAP.md)과 [프로젝트 보드](https://github.com/orgs/cubrid-lab/projects/2)를 참고하세요.
+생태계 전체 관점은 [CUBRID Labs Ecosystem Roadmap](https://github.com/cubrid-lab/.github/blob/main/ROADMAP.md)를 참고하세요.
 
 ## 기여하기
 

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -234,7 +234,7 @@ stmt = insert(users).values(name="Alice").on_duplicate_key_update(name="Alice Up
 
 См. [`ROADMAP.md`](../ROADMAP.md), чтобы узнать о направлении проекта и следующих этапах.
 
-Для обзора по всей экосистеме см. [CUBRID Labs Ecosystem Roadmap](https://github.com/cubrid-lab/.github/blob/main/ROADMAP.md) и [Project Board](https://github.com/orgs/cubrid-lab/projects/2).
+Для обзора по всей экосистеме см. [CUBRID Labs Ecosystem Roadmap](https://github.com/cubrid-lab/.github/blob/main/ROADMAP.md).
 
 ## Участие в проекте
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -232,7 +232,7 @@ stmt = insert(users).values(name="Alice").on_duplicate_key_update(name="Alice Up
 
 项目方向和后续里程碑请参见 [`ROADMAP.md`](../ROADMAP.md)。
 
-生态系统全貌请参见 [CUBRID Labs Ecosystem Roadmap](https://github.com/cubrid-lab/.github/blob/main/ROADMAP.md) 和 [Project Board](https://github.com/orgs/cubrid-lab/projects/2)。
+生态系统全貌请参见 [CUBRID Labs Ecosystem Roadmap](https://github.com/cubrid-lab/.github/blob/main/ROADMAP.md)。
 
 ## 贡献
 


### PR DESCRIPTION
Same link-audit fixes as pycubrid#314: PRD linked the non-existent cubrid-lab/cubrid-cookbook; README + 5 translations linked the private org Project Board (404 for signed-out readers). Roadmap link kept intact.