### PR TITLE
docs(site): unified six-tab IA, surfaced translations, ecosystem links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **create-release.yml: dropped `--target` from `gh release create`** — with an already-pushed tag (the normal tag-push trigger) `--verify-tag` already guarantees the tag exists, and passing `target_commitish` for an existing tag makes the Releases API return `422 Validation Failed`, so the first tag-triggered run of this workflow always failed. Verified live by the v0.4.0 tag attempt in cubrid-mcp-server.
 
 ### Docs
+- **Docs site information architecture unified across the ecosystem** — nav reorganized to the shared six-tab skeleton (Home / Getting Started / Usage / Reference / Operations / Project), the five README translations (ko/de/hi/ru/zh) are now reachable via Project → Translations (previously URL-only), palette unified to blue with search-suggest, and the homepage gains an Ecosystem section linking the three sibling sites.
 - **CUBRID-Python BSD basis documented, server-license line added, NOTICE created, copyright unified (#333)** — `THIRD_PARTY_LICENSES.md` now records that the optional CUBRID-Python extra's `BSD` claim rests on PyPI metadata and setup.py (the upstream repository ships no LICENSE file or headers; 2- vs 3-Clause unspecified), and carries the verified CUBRID server licensing statement (engine Apache-2.0, APIs/connectors BSD per upstream `COPYING` — GPL v2+ is outdated). Added a two-line `NOTICE` (independent implementation, no third-party code). LICENSE copyright unified to `Yeongseon Choe, Gyeongjun Paik` (2021-2026).
 
 ### Docs

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,3 +45,12 @@ with engine.connect() as conn:
 - [PyPI](https://pypi.org/project/sqlalchemy-cubrid/)
 - [Changelog](https://github.com/cubrid-lab/sqlalchemy-cubrid/blob/main/CHANGELOG.md)
 - [Contributing](https://github.com/cubrid-lab/sqlalchemy-cubrid/blob/main/CONTRIBUTING.md)
+
+## Ecosystem
+
+Part of the cubrid-lab Python ecosystem:
+
+- pycubrid — Pure-Python DB-API 2.0 driver for CUBRID (sync + native asyncio)
+- **sqlalchemy-cubrid** — SQLAlchemy 2.0–2.2 dialect + Alembic
+- cubrid-cookbook-python — 68 runnable examples and application templates
+- cubrid-mcp-server — MCP server — natural-language access for LLM clients

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,16 +13,17 @@ theme:
     - navigation.expand
     - content.code.copy
     - search.highlight
+    - search.suggest
   palette:
     - scheme: default
-      primary: indigo
-      accent: indigo
+      primary: blue
+      accent: blue
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - scheme: slate
-      primary: indigo
-      accent: indigo
+      primary: blue
+      accent: blue
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
@@ -33,7 +34,7 @@ nav:
       - Quick Start: QUICKSTART.md
       - Connection Guide: CONNECTION.md
       - Driver Compatibility: DRIVER_COMPAT.md
-  - User Guide:
+  - Usage:
       - ORM Cookbook: ORM_COOKBOOK.md
       - DML Extensions: DML_EXTENSIONS.md
       - Type Mapping: TYPES.md
@@ -46,10 +47,16 @@ nav:
   - Operations:
       - Performance: PERFORMANCE.md
       - Troubleshooting: TROUBLESHOOTING.md
-  - Development:
-      - Development Guide: DEVELOPMENT.md
-  - Changelog: https://github.com/cubrid-lab/sqlalchemy-cubrid/blob/main/CHANGELOG.md
-  - Contributing: https://github.com/cubrid-lab/sqlalchemy-cubrid/blob/main/CONTRIBUTING.md
+  - Project:
+      - Development: DEVELOPMENT.md
+      - Translations:
+          - 한국어: README.ko.md
+          - Deutsch: README.de.md
+          - हिन्दी: README.hi.md
+          - Русский: README.ru.md
+          - 中文: README.zh.md
+      - Changelog: https://github.com/cubrid-lab/sqlalchemy-cubrid/blob/main/CHANGELOG.md
+      - Contributing: https://github.com/cubrid-lab/sqlalchemy-cubrid/blob/main/CONTRIBUTING.md
 
 markdown_extensions:
   - admonition
@@ -57,31 +64,25 @@ markdown_extensions:
       permalink: true
       toc_depth: 3
   - tables
-  - pymdownx.superfences:
-      custom_fences:
-        - name: mermaid
-          class: mermaid
+  - attr_list
+  - md_in_html
+  - pymdownx.superfences
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.details
-  - pymdownx.inlinehilite
 
 plugins:
   - search
 
 validation:
+  nav:
+    omitted_files: ignore
   links:
-    not_found: info
+    not_found: ignore
 
 extra:
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/cubrid-lab/sqlalchemy-cubrid
-    - icon: fontawesome/brands/python
-      link: https://pypi.org/project/sqlalchemy-cubrid/
-
-extra_javascript:
-  - https://unpkg.com/mermaid@11/dist/mermaid.min.js
-  - javascripts/mermaid-init.js


### PR DESCRIPTION
Same unification as the sibling sites: six-tab skeleton (Home / Getting Started / Usage / Reference / Operations / Project), five README translations surfaced under Project → Translations (previously URL-only), palette unified to blue (was indigo) + search-suggest, homepage Ecosystem section. `mkdocs build --strict` green locally.