### PR TITLE
docs: embed demo GIF in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **create-release.yml: dropped `--target` from `gh release create`** — with an already-pushed tag (the normal tag-push trigger) `--verify-tag` already guarantees the tag exists, and passing `target_commitish` for an existing tag makes the Releases API return `422 Validation Failed`, so the first tag-triggered run of this workflow always failed. Verified live by the v0.4.0 tag attempt in cubrid-mcp-server.
 
 ### Docs
+- **Demo GIF embedded in README** — auto-generated terminal demo showing create_engine → connect → execute → result.
 - **Korean/multi-language docs governance** — every `docs/README.<lang>.md` translation now carries a sync marker, and docs-sync gained a `translation-sync` job that fails a PR when `README.md` changes without any translation changing (escape hatch: the `translations-deferred` label).
 - **한국어 문서 페이지 — 배치 5 완결 (#341)** — TROUBLESHOOTING(1,325줄) 번역으로 14페이지 전체 완성.
 - **한국어 문서 페이지 — 배치 4 (#341)** — FEATURE_SUPPORT(기능 비교)·DEVELOPMENT(개발 가이드) 번역 추가. TROUBLESHOOTING만 남음.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ pip install "sqlalchemy-cubrid[cubrid]"
 > this dialect. To select the legacy C-extension driver explicitly and unambiguously,
 > use the `cubrid+cubriddb://` URL together with the `[cubriddb]` install extra.
 
+<img src="docs/demo.gif" alt="sqlalchemy-cubrid in action" width="100%"/>
+
 ## Quick Start
 
 ### Core (Connection-Level)

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -81,6 +81,8 @@ Alembic 지원 포함:
 pip install "sqlalchemy-cubrid[alembic]"
 ```
 
+<img src="https://github.com/cubrid-lab/sqlalchemy-cubrid/raw/main/docs/demo.gif" alt="sqlalchemy-cubrid 데모" width="100%"/>
+
 ## 빠른 시작
 
 ### Core (연결 수준)


### PR DESCRIPTION
Embeds the auto-generated terminal demo GIF directly in the README, following the pattern used by HTTPie (34k stars) and Streamlit (37k stars).

The GIF shows the key value proposition at a glance — no need to read the docs to understand what this package does.

Generated from `demos/*.json` via `demos/render_gif.py` (both committed for reproducibility).